### PR TITLE
mocha: Avoid returning Promise

### DIFF
--- a/src/mocha.coffee
+++ b/src/mocha.coffee
@@ -66,11 +66,13 @@ exports.run = (rt, tests, options) ->
       debug 'started', err
       expectation.noError err
       runner.connect done
+    return null
   after (done) ->
     stop (err) ->
       debug 'stopped', err
       expectation.noError err
       runner.disconnect done
+    return null
 
   for suite in suites
     suite.timeout = options.fixturetimeout if not suite.timeout?


### PR DESCRIPTION
Cannot use both Promise and callback in Mocha 3.x+
Fixes regression introduced in 7df034451d30f