### PR TITLE
Switch to the higher-level fbp-client library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 node_modules/
+package-lock.json
 *.includes
 *.config
 *.autosave

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -152,7 +152,7 @@ module.exports = ->
   @loadNpmTasks 'grunt-mocha-phantomjs'
   @loadNpmTasks 'grunt-exec'
 
-  @registerTask 'examples:bundle', =>
+  @registerTask 'examples:bundle', ->
     examples = require './examples'
     examples.bundle()
 
@@ -183,14 +183,15 @@ module.exports = ->
   @registerTask 'build', 'Build', (target = 'all') =>
     @task.run 'yaml'
     @task.run 'coffee'
-    @task.run 'webpack'
-    @task.run 'examples:bundle'
-    @task.run 'copy:ui'
+    if target != 'nodejs'
+      @task.run 'webpack'
+      @task.run 'examples:bundle'
+      @task.run 'copy:ui'
 
   @registerTask 'test', 'Build and run tests', (target = 'all') =>
     @task.run 'coffeelint'
     @task.run 'yamllint'
-    @task.run 'build'
+    @task.run "build:#{target}"
     @task.run 'mochaTest'
     if target != 'nodejs'
       @task.run 'downloadfile'

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "babel-core": "^6.26.0",
-    "babel-loader": "^7.1.2",
+    "babel-loader": "^7.1.4",
     "babel-preset-es2015": "^6.24.1",
     "coffee-loader": "^0.9.0",
     "coffeelint": "^1.13.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "commander": "~2.9.0",
     "debug": "~2.6.0",
     "fbp": "^1.7.0",
-    "fbp-client": "^0.1.0",
+    "fbp-client": "^0.2.0",
     "fbp-graph": "^0.3.1",
     "js-yaml": "~3.8.3",
     "mocha": "~3.5.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "commander": "~2.9.0",
     "debug": "~2.6.0",
     "fbp": "^1.7.0",
-    "fbp-protocol-client": "~0.2.2",
+    "fbp-client": "^0.1.0",
+    "fbp-graph": "^0.3.1",
     "js-yaml": "~3.8.3",
     "mocha": "~3.5.0",
     "tv4": "~1.3.0"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "coffee-loader": "^0.9.0",
     "coffeelint": "^1.13.0",
     "coffeescript": "^2.0.2",
+    "es6-shim": "^0.35.3",
     "grunt": "^1.0.1",
     "grunt-coffeelint": "^0.0.16",
     "grunt-contrib-coffee": "^2.0.0",
@@ -58,7 +59,6 @@
     "grunt-yaml": "^0.4.2",
     "grunt-yamllint": "https://github.com/gruntjs-updater/grunt-yamllint.git#8e7c04a",
     "isomorphic-fetch": "^2.2.1",
-    "promise-polyfill": "^7.1.0",
     "react": "^0.14.8",
     "webpack": "^3.8.1",
     "websocket": "^1.0.22"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "commander": "~2.9.0",
     "debug": "~2.6.0",
     "fbp": "^1.7.0",
-    "fbp-client": "^0.2.0",
+    "fbp-client": "^0.2.1",
     "fbp-graph": "^0.3.1",
     "js-yaml": "~3.8.3",
     "mocha": "~3.5.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "grunt-yaml": "^0.4.2",
     "grunt-yamllint": "https://github.com/gruntjs-updater/grunt-yamllint.git#8e7c04a",
     "isomorphic-fetch": "^2.2.1",
+    "promise-polyfill": "^7.1.0",
     "react": "^0.14.8",
     "webpack": "^3.8.1",
     "websocket": "^1.0.22"

--- a/spec/cli.coffee
+++ b/spec/cli.coffee
@@ -38,7 +38,7 @@ describe 'fbp-spec', ->
     it 'should exit with 0 code', (done) ->
       @timeout pyTimeout
       fbpSpec example('simple-passing.yaml'), (err) ->
-        chai.expect(err).to.not.exist
+        return done err if err
         done()
 
   describe "with multiple suites and some failing cases", ->

--- a/spec/examples.coffee
+++ b/spec/examples.coffee
@@ -97,7 +97,7 @@ describe 'Examples', ->
                 itOrSkip "should pass", (done) ->
                   @timeout 10000
                   setupAndRun runner, suite, testcase, (err, results) ->
-                    chai.expect(err).to.not.exist
+                    return done err if err
                     chai.expect(results.error).to.not.exist
                     chai.expect(results.passed).to.be.true
                     done()
@@ -105,7 +105,7 @@ describe 'Examples', ->
                 itOrSkip "should fail", (done) ->
                   @timeout 10000
                   setupAndRun runner, suite, testcase, (err, results) ->
-                    chai.expect(err).to.not.exist
+                    return done err if err
                     chai.expect(results.error, 'missing error').to.exist
                     chai.expect(results.error.message).to.contain 'expect'
                     chai.expect(results.passed).to.be.false

--- a/spec/examples.coffee
+++ b/spec/examples.coffee
@@ -19,13 +19,13 @@ else
     address: "ws://localhost:3335"
     command: "python2 protocol-examples/python/runtime.py --port 3335"
 
-startRuntime = (client, info, callback) ->
+startRuntime = (runner, info, callback) ->
   runtime = null
   if info.command
     runtime = fbpspec.subprocess.start info.command, {}, callback
   else if info.protocol == 'iframe'
     parent = document.getElementById 'fixtures'
-    client.setParentElement parent
+    runner.parentElement =  parent
     callback null
   else
     callback null
@@ -52,7 +52,7 @@ describe 'Examples', ->
   before (done) ->
     @timeout 6000
     runner = new fbpspec.runner.Runner runtimeInfo
-    runtime = startRuntime runner.client, runtimeInfo, (err) ->
+    runtime = startRuntime runner, runtimeInfo, (err) ->
       return done err if err
       runner.connect done
   after (done) ->

--- a/spec/mochacompat.coffee
+++ b/spec/mochacompat.coffee
@@ -21,12 +21,13 @@ setupAndConnect = (options, callback) ->
   mochacompat.setup options, (err, state, httpServer) ->
     return callback err if err
     def = runtimeDefinition options
+    client = null
     fbpClient(def)
       .then((c) ->
         client = c
         return client.connect()
       )
-      .then((() -> callback()), callback)
+      .then((() -> callback(null, client, def, state, httpServer)), callback)
     return
   return
 
@@ -35,9 +36,9 @@ runAllComponentTests = (ru, callback) ->
   onUpdate = (s) ->
     state = s
   ru.connect (err) ->
-    return done err if err
+    return callback err if err
     runner.getComponentSuites ru, (err, suites) ->
-      return done err if err
+      return callback err if err
       runner.runAll ru, suites, onUpdate, (err) ->
         return callback err, state
 

--- a/spec/runner.html
+++ b/spec/runner.html
@@ -13,7 +13,7 @@
   <body>
     <div id="mocha"></div>
     <div id="fixtures"></div>
-    <script src="../node_modules/promise-polyfill/dist/polyfill.min.js"></script>
+    <script src="../node_modules/es6-shim/es6-shim.min.js"></script>
     <script src="../node_modules/chai/chai.js"></script>
     <script src="../node_modules/mocha/mocha.js"></script>
     <script src="../examples/bundle.js"></script>

--- a/spec/runner.html
+++ b/spec/runner.html
@@ -13,6 +13,7 @@
   <body>
     <div id="mocha"></div>
     <div id="fixtures"></div>
+    <script src="../node_modules/promise-polyfill/dist/polyfill.min.js"></script>
     <script src="../node_modules/chai/chai.js"></script>
     <script src="../node_modules/mocha/mocha.js"></script>
     <script src="../examples/bundle.js"></script>

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -48,7 +48,7 @@ runOptions = (options, onUpdate, callback) ->
   def =
     protocol: 'websocket'
     address: options.address
-    secret: options.secret
+    secret: options.secret or ''
 
   debug 'runtime info', def
 

--- a/src/mochacompat.coffee
+++ b/src/mochacompat.coffee
@@ -184,7 +184,7 @@ handleFbpCommand = (state, runtime, mocha, specs, protocol, command, payload, co
   updateStatus = (news, event) ->
     state.started = news.started if news.started?
     state.running = news.running if news.running?
-    runtimeState = { started: state.started, running: state.running }
+    runtimeState = { started: state.started, running: state.running, graph: payload.graph }
     debug 'update status', runtimeState
     runtime.send 'network', event, runtimeState, context
 
@@ -267,17 +267,17 @@ handleFbpCommand = (state, runtime, mocha, specs, protocol, command, payload, co
 
   else if protocol == 'network' and command == 'start'
     debug 'FBP network start'
-    updateStatus { started: true, running: false }, 'started'
+    updateStatus { started: true, running: false, graph: payload.graph }, 'started'
   else if protocol == 'network' and command == 'stop'
     debug 'FBP network stop'
-    updateStatus { started: false, running: false }, 'stopped'
+    updateStatus { started: false, running: false, graph: payload.graph }, 'stopped'
 
   ## Component
   else if protocol == 'component' and command == 'list'
     # one fake component per Mocha suite
     for s in specs
       runtime.send 'component', 'component', fbpComponentFromSpec(s), context
-    runtime.send 'component', 'componentsready', {}, context
+    runtime.send 'component', 'componentsready', specs.length, context
 
   else if protocol == 'component' and command == 'getsource'
     # one fake component per Mocha suite

--- a/src/mochacompat.coffee
+++ b/src/mochacompat.coffee
@@ -200,6 +200,7 @@ handleFbpCommand = (state, runtime, mocha, specs, protocol, command, payload, co
       'protocol:graph' # read-only from client
       'protocol:component' # read-only from client
       'protocol:network'
+      'protocol:runtime'
       'component:getsource'
     ]
     info =

--- a/src/protocol.coffee
+++ b/src/protocol.coffee
@@ -90,9 +90,9 @@ exports.getComponentTests = (client, callback) ->
     .then((sources) ->
       tests = {}
       for source in sources
-        continue unless payload.tests
+        continue unless source.tests
         name = if source.library then "#{source.library}/#{source.name}" else source.name
-        tests[name] = payload.tests
+        tests[name] = source.tests
       return tests
     )
     .then(((tests) -> callback(null, tests)), callback)

--- a/src/protocol.coffee
+++ b/src/protocol.coffee
@@ -47,7 +47,6 @@ exports.sendPackets = (client, graphId, packets, callback) ->
   debug 'sendpackets', graphId, packets
 
   Promise.all(Object.keys(packets).map((port) ->
-    console.log port, packets
     return client.protocol.runtime.packet
       event: 'data'
       port: port

--- a/src/protocol.coffee
+++ b/src/protocol.coffee
@@ -37,7 +37,7 @@ exports.startNetwork = (client, graphId, callback) ->
 exports.stopNetwork = (client, graphId, callback) ->
   debug 'stopnetwork', graphId
 
-  client.protocol.network.start(
+  client.protocol.network.stop(
     graph: graphId
   )
     .then((() -> callback()), callback)

--- a/src/runner.coffee
+++ b/src/runner.coffee
@@ -130,16 +130,18 @@ class Runner
   prepareClient: (callback) ->
     if @client.protocol? and @client.address?
       # is a runtime definition
-      fbpClient(@client)
-        .then(((client) =>
+      Promise.resolve()
+        .then(() => fbpClient(@client))
+        .then((client) =>
           @client = client
 
           if @parentElement and client.definition.protocol is 'iframe'
             # We need to set up the parent element in this case
             client.transport.setParentElement @parentElement
 
-          callback null, client
-        ), callback)
+          return client
+        )
+        .nodeify(callback)
       return
     # This is a client instance
     callback null, @client
@@ -172,8 +174,9 @@ class Runner
 
     return callback() unless @client?.isConnected()
 
-    @client.disconnect()
-      .then((() -> callback(null)), callback)
+    Promise.resolve()
+      .then(() => @client.disconnect())
+      .nodeify(callback)
     return
 
   setupSuite: (suite, callback) ->

--- a/src/runner.coffee
+++ b/src/runner.coffee
@@ -254,9 +254,10 @@ class Runner
     sendWait = (data, cb) =>
       sendMessageAndWait @client, @currentGraphId, data.inputs, data.expect, cb
     common.asyncSeries sequence, sendWait, (err, actuals) ->
+      return callback err if err
       actuals.forEach (r, idx) ->
         sequence[idx].actual = r
-      return callback err, sequence
+      return callback null, sequence
     return
 
 # TODO: should this go into expectation?
@@ -310,7 +311,12 @@ runTestAndCheck = (runner, testcase, callback) ->
       error: new Error "Test sequence length mismatch. Got #{inputs.length} inputs and #{expects.length} expectations"
 
   runner.runTest testcase, (err, results) ->
-    return callback err, null if err
+    if err
+      # Map error to a test failure
+      result =
+        passed: false
+        error: err
+      return callback null, result
     result = checkResults results
     if result.error
       result.passed = false

--- a/src/runner.coffee
+++ b/src/runner.coffee
@@ -123,6 +123,7 @@ class Runner
   constructor: (@client, options={}) ->
     @currentGraphId = null
     @components = {}
+    @parentElement = null
     @options = options
     @options.connectTimeout = 5*1000 if not @options.connectTimeout?
 
@@ -132,6 +133,11 @@ class Runner
       fbpClient(@client)
         .then(((client) =>
           @client = client
+
+          if @parentElement and client.definition.protocol is 'iframe'
+            # We need to set up the parent element in this case
+            client.transport.setParentElement @parentElement
+
           callback null, client
         ), callback)
       return

--- a/src/runner.coffee
+++ b/src/runner.coffee
@@ -265,9 +265,10 @@ checkResults = (results) ->
   actuals = results.filter (r) -> r.actual?
   expects = results.filter (r) -> r.expect?
   if actuals.length < expects.length
-    return callback null,
+    result =
       passed: false
       error: new Error "Only got #{actual.length} output messages out of #{expect.length}"
+    return result
 
   results = results.map (res) ->
     res.error = null

--- a/src/runner.coffee
+++ b/src/runner.coffee
@@ -181,6 +181,9 @@ class Runner
     debug 'setup suite', "\"#{suite.name}\""
     return callback null if not needsSetup suite
 
+    unless @client.isConnected()
+      return callback new Error 'Disconnected from runtime'
+
     getFixtureGraph this, suite, (err, graph) =>
       return callback err if err
       protocol.sendGraph @client, graph, (err, graphId) =>
@@ -194,12 +197,18 @@ class Runner
     debug 'teardown suite', "\"#{suite.name}\""
     return callback null if not needsSetup suite
 
+    unless @client.isConnected()
+      return callback new Error 'Disconnected from runtime'
+
     # FIXME: also remove the graph. Ideally using a 'destroy' message in FBP protocol
     protocol.stopNetwork @client, @currentGraphId, callback
     return
 
   runTest: (testcase, callback) ->
     debug 'runtest', "\"#{testcase.name}\""
+
+    unless @client.isConnected()
+      return callback new Error 'Disconnected from runtime'
 
     # XXX: normalize and validate in testsuite.coffee instead?
     inputs = if common.isArray(testcase.inputs) then testcase.inputs else [ testcase.inputs ]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,17 @@ module.exports = {
           }
         ]
       },
+      {
+        test: /\.js$/,
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              presets: ['es2015'],
+            }
+          }
+        ]
+      },
     ]
   },
   resolve: {


### PR DESCRIPTION
This way we get a nice Promise API for interacting with the runtime.

However, this is likely a breaking change since fbp-client actually validates all responses from the runtime. Some runtimes will have problems with this.

Fixes #137
Fixes #136 
Fixes #118 
Fixes #72 
Fixes #71
Fixes #12
Fixes #11