### PR TITLE
Fix command timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
     "isomorphic-fetch": "^2.2.1",
     "react": "^0.14.8",
     "webpack": "^3.8.1",
-    "websocket": "^1.0.22"
+    "websocket": "^1.0.26"
   }
 }

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -16,6 +16,7 @@ parse = (args) ->
     .option('--secret <secret>', 'Runtime secret', String, null)
     .option('--command <command>', 'Command to launch runtime under test', String, null)
     .option('--start-timeout <seconds>', 'Time to wait for runtime to start', Number, 10)
+    .option('--command-timeout <seconds>', 'Max time for a FBP command', Number, 3)
     .parse(process.argv)
 
   return program
@@ -54,6 +55,7 @@ runOptions = (options, onUpdate, callback) ->
 
   runnerOptions =
     connectTimeout: options.startTimeout*1000
+    commandTimeout: options.commandTimeout*1000
 
   ru = new runner.Runner def, runnerOptions
   child = startRuntime options, (err) ->

--- a/src/mocha.coffee
+++ b/src/mocha.coffee
@@ -44,6 +44,7 @@ exports.run = (rt, tests, options) ->
 
   runnerOptions =
     connectTimeout: options.starttimeout
+    commandTimeout: options.commandtimeout
   runner = new Runner rt, runnerOptions
   try
     suites = testsuite.getSuitesSync tests

--- a/src/runner.coffee
+++ b/src/runner.coffee
@@ -153,12 +153,13 @@ class Runner
     @parentElement = null
     @options = options
     @options.connectTimeout = 5*1000 if not @options.connectTimeout?
+    @options.commandTimeout = 3*1000 if not @options.commandTimeout?
 
   prepareClient: (callback) ->
     if @client.protocol? and @client.address?
       # is a runtime definition
       Promise.resolve()
-        .then(() => fbpClient(@client))
+        .then(() => fbpClient(@client, { commandTimeout: @options.commandTimeout }))
         .then((client) =>
           @client = client
 


### PR DESCRIPTION

network:stop in particular can be slow, depending on network complexity and what components do in their `shutdown` function.
The default timeout was just 1 second, this bumps it to 3 seconds, and makes it configurable for even slower cases.
This fixes in crashes like:

```
/home/jon/work/flowhub/bigiot-bridge/node_modules/bluebird/js/release/async.js:61
        fn = function () { throw arg; };
                           ^
Error: network:stop timed out
    at Timeout.setTimeout [as _onTimeout] (../node_modules/fbp-client/lib/adapter/0_x.js:158:18)
    at ontimeout (timers.js:427:11)
    at tryOnTimeout (timers.js:289:5)
    at listOnTimeout (timers.js:252:5)
    at Timer.processTimers (timers.js:212:10)
npm ERR! Test failed.  See above for more details.
```