### PR TITLE
If network setup failed, skip teardown

### DIFF
--- a/src/runner.coffee
+++ b/src/runner.coffee
@@ -242,6 +242,11 @@ class Runner
     unless @client.isConnected()
       return callback new Error 'Disconnected from runtime'
 
+    unless @currentGraphId
+      # Graph was never successfully set up, so no need to stop
+      do callback
+      return
+
     # FIXME: also remove the graph. Ideally using a 'destroy' message in FBP protocol
     protocol.stopNetwork @client, @currentGraphId, callback
     return


### PR DESCRIPTION
If setup fails, we get an error also at teardown. Like here:

```
  1) c-flo participants
       Fetching airport weather
         "before each" hook for "should return temperature and humidity":
     Error: graph:addnode timed out
    at Timeout.setTimeout (node_modules/fbp-client/lib/adapter/0_x.js:158:18)
  
  2) c-flo participants
       Fetching airport weather
         "after each" hook for "should return temperature and humidity":
     Error: Client sent invalid payload for network:stop: data.payload should have required property 'graph'
```