### PR TITLE
Ignore failing getSource requests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 0.6.8 - git master
+
+* Made fbp-spec ignore failing getSource requests
+
 # 0.6.7 - released 01.09.2020
 
 * Updated dependencies to include latest FBP Protocol Client and Schemas

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "fbp-spec-mocha": "./bin/fbp-spec-mocha"
   },
   "dependencies": {
-    "JSONPath": "~0.11.2",
+    "jsonpath": "^1.0.2",
     "bluebird": "^3.5.0",
     "chai": "~4.1.0",
     "commander": "~2.16.0",

--- a/src/expectation.coffee
+++ b/src/expectation.coffee
@@ -42,11 +42,9 @@ findOperator = (expectation) ->
   throw new Error "fbp-spec: No operator matching #{Object.keys(expectation)}. Available: #{Object.keys(operators)}"
 
 extractMatches = (expectation, data) ->
-  options =
-    flatten: true
   if expectation.path
     debug 'extracting JSONPath from', expectation.path, data
-    matches = JSONPath.query data, expectation.path, options
+    matches = JSONPath.query data, expectation.path
     throw new Error("expected JSONPath '#{expectation.path}' to match data in #{JSON.stringify(data)}") if not matches.length
   else
     matches = [ data ]

--- a/src/expectation.coffee
+++ b/src/expectation.coffee
@@ -1,7 +1,7 @@
 
 debug = require('debug')('fbp-spec:expectation')
 chai = require 'chai'
-JSONPath = require 'JSONPath'
+JSONPath = require 'jsonpath'
 
 common = require './common'
 
@@ -46,7 +46,7 @@ extractMatches = (expectation, data) ->
     flatten: true
   if expectation.path
     debug 'extracting JSONPath from', expectation.path, data
-    matches = JSONPath.eval data, expectation.path, options
+    matches = JSONPath.query data, expectation.path, options
     throw new Error("expected JSONPath '#{expectation.path}' to match data in #{JSON.stringify(data)}") if not matches.length
   else
     matches = [ data ]

--- a/src/protocol.coffee
+++ b/src/protocol.coffee
@@ -91,8 +91,14 @@ exports.getComponentTests = (client, callback) ->
     .then(() -> client.protocol.component.list())
     .then((components) ->
       return Promise.all(components.map((component) ->
-        client.protocol.component.getsource
+        client.protocol.component.getsource(
           name: component.name
+        ).then(
+          (source) -> source
+          (err) -> {
+            tests: null
+          }
+        )
       ))
     )
     .then((sources) ->


### PR DESCRIPTION
For instance dynamically loaded NoFlo components don't have sources available. fbp-spec only tries loading them to find any tests to execute from runtime side, so they can be safely ignored.